### PR TITLE
Change the type of throw

### DIFF
--- a/src/Control/Monad/Trans/Has/Except.hs
+++ b/src/Control/Monad/Trans/Has/Except.hs
@@ -14,5 +14,5 @@ import qualified Control.Monad.Trans.Except as Control.Monad.Trans.Has
 
 type HasExcept e m = Has (ExceptT e) m
 
-throw :: HasExcept e m => e -> m ()
+throw :: HasExcept e m => e -> m a
 throw e = liftH $ ExceptT $ return $ Left e


### PR DESCRIPTION
Make the type of "throw" more flexible by leaving the type inside the monad arbitrary.